### PR TITLE
add destructor to linux implementation

### DIFF
--- a/include/udp_lib_linux.hpp
+++ b/include/udp_lib_linux.hpp
@@ -90,6 +90,14 @@ namespace udp
             }
         }
 
+		~UDPLib()
+		{
+			int result = close(sock_);
+			if (result == -1) {
+				std::cerr << "[Error] Failed to close socket." << std::endl;
+			}
+		}
+
         void udp_bind() const
         {
             if (bind(sock_, (const struct sockaddr *)&addr_, sizeof(addr_)) < 0)


### PR DESCRIPTION
close the socket when the object is destructed

Otherwise, repeated creation of the UDPLib object (using the same port) would fail.